### PR TITLE
Enable query plan fpr pdpgsql pg_stat_monitor

### DIFF
--- a/pmm_qa/pg_stat_monitor_setup.sh
+++ b/pmm_qa/pg_stat_monitor_setup.sh
@@ -102,6 +102,7 @@ echo "track_activity_query_size=2048"  >> /etc/postgresql/${pgsql_version}/main/
 echo "track_io_timing=ON"  >> /etc/postgresql/${pgsql_version}/main/postgresql.conf
 echo "max_connections=1000"  >> /etc/postgresql/${pgsql_version}/main/postgresql.conf
 echo "listen_addresses = '*'"  >> /etc/postgresql/${pgsql_version}/main/postgresql.conf
+echo "pg_stat_monitor.pgsm_enable_query_plan = 'yes'" >> /etc/postgresql/${pgsql_version}/main/postgresql.conf
 
 # Create init.sql file required by PMM
 echo "CREATE DATABASE sbtest1;" >> /home/postgres/init.sql


### PR DESCRIPTION
QAN pg_stat plan : https://13.58.247.229/graph/d/pmm-qan/pmm-query-analytics?var-service_name=pdpgsql_pgsm_pmm_16_service_9273&var-environment=All&var-cluster=All&var-replication_set=All&var-database=All&var-schema=All&var-node_name=All&var-client_host=All&var-username=All&var-service_type=All&var-node_type=All&var-city=All&var-az=All&var-interval=auto&columns=%5B%22load%22,%22num_queries%22,%22query_time%22%5D&group_by=queryid&selected_query_database=postgres&filter_by=8749750121111192242&order_by=-load&from=now-12h&to=now&page_number=1&page_size=25&totals=false&query_selected&details_tab=plan