### PR TITLE
Fix PGSM-PMM integration tests for PG14/15, fix CI workflows in this repo

### DIFF
--- a/.github/workflows/PMM_PDPGSQL.yaml
+++ b/.github/workflows/PMM_PDPGSQL.yaml
@@ -80,7 +80,7 @@ jobs:
       run: git clone https://github.com/percona/pmm-ui-tests.git && cd pmm-ui-tests && npm ci
 
     - name: Install npx dependencies
-      run: sudo npx playwright install-deps && npx codeceptjs def pr.codecept.js
+      run: sudo npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
       working-directory: pmm-ui-tests
       
     - name: Run the Integration tests of pdpgsql

--- a/.github/workflows/PMM_PDPGSQL.yaml
+++ b/.github/workflows/PMM_PDPGSQL.yaml
@@ -80,7 +80,7 @@ jobs:
       run: git clone https://github.com/percona/pmm-ui-tests.git && cd pmm-ui-tests && npm ci
 
     - name: Install npx dependencies
-      run: sudo npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
+      run: npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
       working-directory: pmm-ui-tests
       
     - name: Run the Integration tests of pdpgsql

--- a/.github/workflows/PMM_PROXYSQL.yaml
+++ b/.github/workflows/PMM_PROXYSQL.yaml
@@ -91,7 +91,8 @@ jobs:
       run: git clone https://github.com/percona/pmm-ui-tests.git && cd pmm-ui-tests && npm ci
 
     - name: Install npx dependencies
-      run: cd pmm-ui-tests && sudo npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
+      run: npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
+      working-directory: pmm-ui-tests
       
     - name: Run the Integration tests of PXC
       run: npx codeceptjs run -c pr.codecept.js tests/qa-integration/pmm_pxc_integration_test.js --steps --debug

--- a/.github/workflows/PMM_PROXYSQL.yaml
+++ b/.github/workflows/PMM_PROXYSQL.yaml
@@ -91,7 +91,7 @@ jobs:
       run: git clone https://github.com/percona/pmm-ui-tests.git && cd pmm-ui-tests && npm ci
 
     - name: Install npx dependencies
-      run: cd pmm-ui-tests && sudo npx playwright install-deps && npx codeceptjs def pr.codecept.js
+      run: cd pmm-ui-tests && sudo npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
       
     - name: Run the Integration tests of PXC
       run: npx codeceptjs run -c pr.codecept.js tests/qa-integration/pmm_pxc_integration_test.js --steps --debug

--- a/.github/workflows/PMM_PS.yaml
+++ b/.github/workflows/PMM_PS.yaml
@@ -92,7 +92,7 @@ jobs:
       run: git clone https://github.com/percona/pmm-ui-tests.git && cd pmm-ui-tests && npm ci
 
     - name: Install npx dependencies
-      run: sudo npx playwright install-deps && npx codeceptjs def pr.codecept.js
+      run: sudo npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
       working-directory: pmm-ui-tests
       
     - name: Run the Integration tests of PS

--- a/.github/workflows/PMM_PS.yaml
+++ b/.github/workflows/PMM_PS.yaml
@@ -92,7 +92,7 @@ jobs:
       run: git clone https://github.com/percona/pmm-ui-tests.git && cd pmm-ui-tests && npm ci
 
     - name: Install npx dependencies
-      run: sudo npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
+      run: npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
       working-directory: pmm-ui-tests
       
     - name: Run the Integration tests of PS

--- a/.github/workflows/PMM_PXC.yaml
+++ b/.github/workflows/PMM_PXC.yaml
@@ -91,7 +91,8 @@ jobs:
       run: git clone https://github.com/percona/pmm-ui-tests.git && cd pmm-ui-tests && npm ci
 
     - name: Install npx dependencies
-      run: cd pmm-ui-tests && sudo npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
+      run: npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
+      working-directory: pmm-ui-tests
       
     - name: Run the Integration tests of PXC
       run: npx codeceptjs run -c pr.codecept.js tests/qa-integration/pmm_pxc_integration_test.js --steps --debug

--- a/.github/workflows/PMM_PXC.yaml
+++ b/.github/workflows/PMM_PXC.yaml
@@ -91,7 +91,7 @@ jobs:
       run: git clone https://github.com/percona/pmm-ui-tests.git && cd pmm-ui-tests && npm ci
 
     - name: Install npx dependencies
-      run: cd pmm-ui-tests && sudo npx playwright install-deps && npx codeceptjs def pr.codecept.js
+      run: cd pmm-ui-tests && sudo npx playwright install --with-deps && npx codeceptjs def pr.codecept.js
       
     - name: Run the Integration tests of PXC
       run: npx codeceptjs run -c pr.codecept.js tests/qa-integration/pmm_pxc_integration_test.js --steps --debug

--- a/pmm_pgsm_setup/pmm_pgsm_setup.sh
+++ b/pmm_pgsm_setup/pmm_pgsm_setup.sh
@@ -83,6 +83,7 @@ sudo rm -r pmm-ui-tests || true ## Delete if the Repo already checkedout
 git clone -b ${PMM_UI_BRANCH} https://github.com/percona/pmm-ui-tests
 pushd pmm-ui-tests
 npm install --force
+npx playwright install
 export PMM_UI_URL="http://127.0.0.1:8081/"
 ./node_modules/.bin/codeceptjs run --debug --steps -c pr.codecept.js --grep '@pgsm-pmm-integration'
 popd


### PR DESCRIPTION
This PR fixes the same problem for PMM-PGSM integration tests and CI workflows in this repo:
```
Error: browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium-1117/chrome-linux/chrome
╔═════════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just installed or updated. ║
║ Please run the following command to download new browsers:              ║
║                                                                         ║
║     npx playwright install                                              ║
║                                                                         ║
║ <3 Playwright Team                                                      ║
╚═════════════════════════════════════════════════════════════════════════╝
```
CI workflows in this PR still failing, but now it's actual tests failures.

Integration tests run in PGSM repo with this branch: https://github.com/percona/pg_stat_monitor/pull/477

