### PR TITLE
Update to expose minio port number on 9001

### DIFF
--- a/pmm_psmdb-pbm_setup/docker-compose-rs.yaml
+++ b/pmm_psmdb-pbm_setup/docker-compose-rs.yaml
@@ -186,6 +186,8 @@ services:
     image: minio/minio
     profiles: ["classic", "extra"]
     container_name: minio
+    ports:
+      - "9001:9000"
     depends_on:
       - build_member
     networks:

--- a/pmm_psmdb-pbm_setup/docker-compose-sharded.yaml
+++ b/pmm_psmdb-pbm_setup/docker-compose-sharded.yaml
@@ -229,7 +229,7 @@ services:
     image: minio/minio
     container_name: minio
     ports:
-      - "9001:9001"
+      - "9001:9000"
     networks:
       - test-network
     volumes:
@@ -247,7 +247,7 @@ services:
     depends_on:
       - minio
     entrypoint: >
-      /bin/sh -c " sleep 5; /usr/bin/mc config host add myminio http://minio:9001 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
+      /bin/sh -c " sleep 5; /usr/bin/mc config host add myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
 
   pmm-server:
     image: ${PMM_IMAGE:-perconalab/pmm-server:3-dev-latest}

--- a/pmm_psmdb-pbm_setup/docker-compose-sharded.yaml
+++ b/pmm_psmdb-pbm_setup/docker-compose-sharded.yaml
@@ -229,7 +229,7 @@ services:
     image: minio/minio
     container_name: minio
     ports:
-      - "9000:9000"
+      - "9001:9001"
     networks:
       - test-network
     volumes:
@@ -247,7 +247,7 @@ services:
     depends_on:
       - minio
     entrypoint: >
-      /bin/sh -c " sleep 5; /usr/bin/mc config host add myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
+      /bin/sh -c " sleep 5; /usr/bin/mc config host add myminio http://minio:9001 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
 
   pmm-server:
     image: ${PMM_IMAGE:-perconalab/pmm-server:3-dev-latest}

--- a/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
+++ b/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
@@ -99,6 +99,8 @@ services:
   minio:
     image: minio/minio
     container_name: minio
+    ports:
+      - "9001:9000"
     volumes:
       - /tmp/minio/backups:/backups
     environment:


### PR DESCRIPTION
Fix minio port number, as we start pmm-sever on 9000 already in pipelines

out tests on pipeline results : https://github.com/percona/pmm-qa/actions/runs/11888886744/job/33124333617