### PR TITLE
PMM-13805 Added support to setup PMM3 with PPG & PGSM from PPG testing repos.

### DIFF
--- a/pmm_qa/pdpgsql_pgsm_setup.yml
+++ b/pmm_qa/pdpgsql_pgsm_setup.yml
@@ -17,6 +17,8 @@
     use_socket: "{{ lookup('vars', 'extra_pdpgsql_version', default=lookup('env','USE_SOCKET') | default('', true) ) }}"
     pdpgsql_pgsm_port: "{{ lookup('vars', 'extra_pdpgsql_port', default=lookup('env','PDPGSQL_PGSM_PORT') | default(5447, true) ) }}"
     distribution: "{{ lookup('vars', 'extra_pdpgsql_distribution', default=lookup('env','DISTRIBUTION') | default('PPG', true) ) }}"
+    ppg_repo_version: "{{ lookup('vars', 'extra_ppg_repo_version', default=lookup('env','PPG_REPO_VERSION') | default('', true) ) }}"
+    ppg_repo_type: "{{ lookup('vars', 'extra_ppg_repo_type', default=lookup('env','PPG_REPO_TYPE') | default('', true) ) }}"
 
   tasks:
   - name: cleanup container for client and DB setup
@@ -47,7 +49,7 @@
   - name: Execute Setup script inside the pdpgsql pdpgsql_pgsm_container
     shell: "{{ item }}"
     with_items:
-      - docker exec {{ pdpgsql_pgsm_container }} bash -xe ./pg_stat_monitor_setup.sh --distribution {{ distribution }} --pgsql_version {{ pdpgsql_version }} --pgstat_monitor_branch {{ pgstat_monitor_branch }} --pgstat_monitor_repo {{ pgstat_monitor_repo }} > setup_{{ pdpgsql_pgsm_container }}.log
+      - docker exec {{ pdpgsql_pgsm_container }} bash -xe ./pg_stat_monitor_setup.sh --distribution {{ distribution }} --pgsql_version {{ pdpgsql_version }} --pgstat_monitor_branch {{ pgstat_monitor_branch }} --pgstat_monitor_repo {{ pgstat_monitor_repo }} --ppg_repo_version {{ ppg_repo_version }} --ppg_repo_type {{ ppg_repo_type }} > setup_{{ pdpgsql_pgsm_container }}.log
 
   - name: Install pmm2-client on the pdpgsql_pgsm_container
     shell: "{{ item }}"


### PR DESCRIPTION
PMM-13805 Added support to setup PMM3 with PPG & PGSM from PPG testing repos.

*For PPG we have following repo structure available, and this commit makes sure we can use minor version testing or release repo. Release
    -Major: like ppg-16
    -Minor: like ppg-16.8
Testing
    -Minor: like ppg-16.8
    -There is no MAJOR repo under testing repo

*For using Minor Version testing repo repo, following ENV variable should be used. export PDPGSQL_VERSION=15 # Major Verion Only
export PPG_REPO_VERSION=15.12
export PPG_REPO_TYPE=testing
python pmm-framework.py --database PDPGSQL --verbose

*For using Minor Version release repo repo, following ENV variable should be used. export PDPGSQL_VERSION=15 # Major Verion Only
export PPG_REPO_VERSION=15.12
export PPG_REPO_TYPE=release
python pmm-framework.py --database PDPGSQL --verbose

*Already existing use case with Release repo will work as before. export PDPGSQL_VERSION=15 # Major Verion Only
python pmm-framework.py --database PDPGSQL --verbose