### PR TITLE
PBM replace deprecated mc config command

### DIFF
--- a/pmm_psmdb-pbm_setup/docker-compose-rs.yaml
+++ b/pmm_psmdb-pbm_setup/docker-compose-rs.yaml
@@ -213,7 +213,7 @@ services:
     depends_on:
       - minio
     entrypoint: >
-      /bin/sh -c " sleep 5; /usr/bin/mc config host add myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
+      /bin/sh -c " sleep 5; /usr/bin/mc alias set myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
 
 networks:
   qa-integration:

--- a/pmm_psmdb-pbm_setup/docker-compose-sharded.yaml
+++ b/pmm_psmdb-pbm_setup/docker-compose-sharded.yaml
@@ -244,7 +244,7 @@ services:
     depends_on:
       - minio
     entrypoint: >
-      /bin/sh -c " sleep 5; /usr/bin/mc config host add myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
+      /bin/sh -c " sleep 5; /usr/bin/mc alias set myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
 
   pmm-server:
     image: ${PMM_IMAGE:-perconalab/pmm-server:dev-latest}

--- a/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
+++ b/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
@@ -107,7 +107,7 @@ services:
     depends_on:
       - minio
     entrypoint: >
-      /bin/sh -c " sleep 5; /usr/bin/mc config host add myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
+      /bin/sh -c " sleep 5; /usr/bin/mc alias set myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
 
 volumes:
   psmdb-server-data:


### PR DESCRIPTION
Replaced deprecated `mc config` command with `mc alias`
See https://github.com/minio/mc/pull/5201 