### PR TITLE
PMM-7 Bitnami legacy

### DIFF
--- a/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
+++ b/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
@@ -88,7 +88,7 @@ services:
   ldap-server:
     container_name: ldap-server
     hostname: ldap-server
-    image: bitnami/openldap
+    image: bitnamilegacy/openldap
     environment:
       - LDAP_ADMIN_USERNAME=admin
       - LDAP_ADMIN_PASSWORD=adminpassword
@@ -98,7 +98,7 @@ services:
       - '1389:1389'
       - '1636:1636'
     volumes:
-      - 'openldap-data:/bitnami/openldap'
+      - 'openldap-data:/bitnamilegacy/openldap'
 
   kerberos:
     image: kerberos/local


### PR DESCRIPTION
This pull request updates the configuration for the LDAP server in the `pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml` file. The changes primarily focus on switching to a legacy image and updating the associated volume path.

LDAP server configuration updates:

* Changed the LDAP server image from `bitnami/openldap` to `bitnamilegacy/openldap` to use the legacy version.
* Updated the volume mount path from `/bitnami/openldap` to `/bitnamilegacy/openldap` to match the new legacy image requirements.